### PR TITLE
Expose enum constants

### DIFF
--- a/src/app/Classes/Enum.php
+++ b/src/app/Classes/Enum.php
@@ -14,7 +14,7 @@ class Enum
         //
     }
 
-    private static function constants()
+    public static function constants()
     {
         $constants = array_flip(
             (new ReflectionClass(static::class))


### PR DESCRIPTION
Allows exposing the constants for usage in frontend (where $data is being used for _more descriptive_ labels)