### PR TITLE
fixes filled method

### DIFF
--- a/src/app/Classes/Obj.php
+++ b/src/app/Classes/Obj.php
@@ -19,7 +19,7 @@ class Obj extends Collection
 
     public function filled(string $key)
     {
-        return ! empty($this->get($key));
+        return ! is_null($this->get($key));
     }
 
     private function init($items)

--- a/src/app/Classes/Obj.php
+++ b/src/app/Classes/Obj.php
@@ -19,7 +19,9 @@ class Obj extends Collection
 
     public function filled(string $key)
     {
-        return ! is_null($this->get($key));
+        return is_array($this->get($key))
+            ? ! empty($this->get($key))
+            : $this->get($key) !== null;
     }
 
     private function init($items)


### PR DESCRIPTION
Fixes a bug where filled() would return `false` instead of `true` when `falsey` values are provided.

![image](https://user-images.githubusercontent.com/37445394/62922038-19228880-bdb3-11e9-99d4-a0f70d243b2f.png)
